### PR TITLE
README.md referencing the wrong flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ When developing a project in Supabase, you can choose to develop locally or dire
 1. Link your CLI to the project.
 
    ```shell
-   npx supabase link --project-id=<project-id>
+   npx supabase link --project-ref=<project-id>
    ```
 
    You can get the project ID from the [general settings page](https://supabase.com/dashboard/project/_/settings/general).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update documentation and guide 
## What is the current behavior?
flag `--project-id=<project-id>` throws an error

## What is the new behavior?
change to the right flag `--project-ref=<project-ref>` as referenced in the docs.

## Additional context
Minor type