### PR TITLE
Fix: Change suggested batch size to 5 to help with cpu limit issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ Now let's add logic to generate embeddings automatically anytime new rows are ad
       after insert on document_sections
       referencing new table as inserted
       for each statement
-      execute procedure private.embed(content, embedding, 10);
+      execute procedure private.embed(content, embedding, 5); -- changed this to 5 to help with reports of CPU limits reached
     ```
 
     Note we pass 3 arguments to `embed()`:

--- a/supabase/migrations/20231007002735_embed.sql
+++ b/supabase/migrations/20231007002735_embed.sql
@@ -54,4 +54,4 @@ create trigger embed_document_sections
   after insert on document_sections
   referencing new table as inserted
   for each statement
-  execute procedure private.embed(content, embedding, 10);
+  execute procedure private.embed(content, embedding, 5);


### PR DESCRIPTION
## Problem
The `embed` trigger batch size of 10 resulted in some users reporting CPU limits being reached in edge functions.

## Solution
Lowering this to 5 in hopes that the edge function will be able to complete 5 embeddings at a time without hitting CPU limits.