### PR TITLE
Gracefully handle bucket conflicts during insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,8 @@ When developing a project in Supabase, you can choose to develop locally or dire
 
     ```sql
     insert into storage.buckets (id, name)
-    values ('files', 'files');
+    values ('files', 'files')
+    on conflict do nothing;
     ```
 
 1.  Add RLS policies to restrict access to files.

--- a/supabase/migrations/20231006192603_files.sql
+++ b/supabase/migrations/20231006192603_files.sql
@@ -1,7 +1,8 @@
 create schema private;
 
 insert into storage.buckets (id, name)
-values ('files', 'files');
+values ('files', 'files')
+on conflict do nothing;
 
 create or replace function private.uuid_or_null(str text)
 returns uuid


### PR DESCRIPTION
## Problem
For users following the cloud flow and attempting to use:

```shell
npx supabase db reset --linked
```

to reset their remote database, they get the error `duplicate key value violates unique constraint "buckets_pkey"`.

## Solution
Change

```sql
insert into storage.buckets (id, name)
values ('files', 'files');
```

to gracefully handle conflicts:
```sql
insert into storage.buckets (id, name)
values ('files', 'files')
on conflict do nothing;
```
