### PR TITLE
chore: upgrade supabase cli to v1.127.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/react": "18.2.12",
         "@types/react-dom": "18.2.5",
         "encoding": "^0.1.13",
-        "supabase": "^1.102.0"
+        "supabase": "^1.127.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/supabase": {
-      "version": "1.102.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-1.102.0.tgz",
-      "integrity": "sha512-fgqYugWnAWTlGisMt0ZKPquHsHfwhgCxbyQZdWii+BLuUYSQc9qNSNdkQ3eaAOsmdoIckQLaWTvIwOtx6UFT/w==",
+      "version": "1.127.4",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-1.127.4.tgz",
+      "integrity": "sha512-9vxMsRkG8Qqju+gjTL++G/DaUcMyVr9YAT3jeRkNKIzbVVd0QiHUp2NHXXlqs6EByJVZzpMYJf4h55ml/H7gpg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",
     "encoding": "^0.1.13",
-    "supabase": "^1.102.0"
+    "supabase": "^1.127.4"
   }
 }


### PR DESCRIPTION
Upgrades `supabase` CLI to latest v1.127.4 which uses edge-runtime v1.29.1.