### PR TITLE
fix: increase pg_net http timeout

### DIFF
--- a/supabase/migrations/20231007002735_embed.sql
+++ b/supabase/migrations/20231007002735_embed.sql
@@ -12,10 +12,13 @@
 -- for each statement
 -- execute procedure private.embed(<content_column>, <embedding_column>);
 --
--- Expects 3 arguments: `private.embed(<content_column>, <embedding_column>, <batch_size>)`
+-- Expects 2 arguments: `private.embed(<content_column>, <embedding_column>)`
 -- where the first argument indicates the source column containing the text content,
--- the second argument indicates the destination column to store the embedding,
--- and the third argument indicates the number of records to include in each edge function call.
+-- and the second argument indicates the destination column to store the embedding.
+--
+-- Also supports 2 more optional arguments: `private.embed(<content_column>, <embedding_column>, <batch_size>, <timeout_milliseconds>)`
+-- where the third argument indicates the number of records to include in each edge function call (default 5),
+-- and the fourth argument specifies the HTTP connection timeout for each edge function call (default 300000 ms).
 create function private.embed() 
 returns trigger 
 language plpgsql
@@ -23,13 +26,13 @@ as $$
 declare
   content_column text = TG_ARGV[0];
   embedding_column text = TG_ARGV[1];
-  batch_size int = TG_ARGV[2];
+  batch_size int = case when array_length(TG_ARGV, 1) >= 3 then TG_ARGV[2]::int else 5 end;
+  timeout_milliseconds int = case when array_length(TG_ARGV, 1) >= 4 then TG_ARGV[3]::int else 5 * 60 * 1000 end;
   batch_count int = ceiling((select count(*) from inserted) / batch_size::float);
-  result int;
 begin
-
+  -- Loop through each batch and invoke an edge function to handle the embedding generation
   for i in 0 .. (batch_count-1) loop
-  select
+  perform
     net.http_post(
       url := supabase_url() || '/functions/v1/embed',
       headers := jsonb_build_object(
@@ -41,9 +44,9 @@ begin
         'table', TG_TABLE_NAME,
         'contentColumn', content_column,
         'embeddingColumn', embedding_column
-      )
-    )
-  into result;
+      ),
+      timeout_milliseconds := timeout_milliseconds
+    );
   end loop;
 
   return null;
@@ -54,4 +57,4 @@ create trigger embed_document_sections
   after insert on document_sections
   referencing new table as inserted
   for each statement
-  execute procedure private.embed(content, embedding, 5);
+  execute procedure private.embed(content, embedding);


### PR DESCRIPTION
## Problem
We were consistently seeing this error in the `embed` edge function:
```
client connection error (hyper::Error(IncompleteMessage))
```

Which was caused by the `pg_net` HTTP client closing the connecting too early due to a timeout (2000 ms).

## Solution
Generating embeddings can take time, so this PR increases the timeout to 300000 ms (5 minutes) by default, and also allows you to specify a custom timeout via an optional fourth trigger argument:

```sql
create trigger embed_document_sections
  after insert on document_sections
  referencing new table as inserted
  for each statement
  execute procedure private.embed(content, embedding, 5, 300000);
```

Fixes https://github.com/supabase-community/chatgpt-your-files/issues/11.