### PR TITLE
Update README.md with correct Vercel deploy guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1686,7 +1686,7 @@ If you've been developing the app locally, follow these instructions to deploy y
 
 1. Deploy to Vercel _(or CDN of your choice - must support Next.js API routes for authentication)_.
 
-   - Follow Vercel’s [deploy instructions](https://nextjs.org/learn/basics/deploying-nextjs-app/deploy).
+   - Follow Vercel’s [deploy instructions](https://nextjs.org/docs/app/getting-started/deploying).
    - Be sure to set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` for your Supabase project.
 
      You can find these in your [project’s API settings](https://supabase.com/dashboard/project/_/settings/api).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates `README.md` with correct link from Vercel docs on how to deploy.

## What is the current behavior?

Leads to a 404 page 😢 :
![CleanShot 2025-05-25 at 23 59 06@2x](https://github.com/user-attachments/assets/af004d66-214c-4434-a24c-5dd8a17e98e5)


## What is the new behavior?

Goes to the correct page! 🎉 :
![CleanShot 2025-05-25 at 23 59 48@2x](https://github.com/user-attachments/assets/142b86f5-9ecd-4428-9c35-4a56bc080ae4)
