### PR TITLE
Add opt-in AgentPond tracing for Supabase Edge chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1648,6 +1648,32 @@ Jump to a previous step:
 5. [Database Types](#step-5---database-types-bonus) (Bonus)
 6. [You're done!](#youre-done)
 
+### Optional AgentPond AI tracing
+
+Apply the latest migrations and set the Edge Function secret
+`AGENTPOND_ENABLED=true` to export OpenInference traces directly to the private
+`agentpond` bucket:
+
+```bash
+npx supabase db push
+npx supabase secrets set AGENTPOND_ENABLED=true
+```
+
+Supabase automatically supplies the server-only project credentials used by
+the exporter. The chat span explicitly uses `recordInputs: true` and
+`recordOutputs: true`, recording the complete document context, chat messages,
+and generated response. This can include personal or confidential content, so
+review access, retention, and consent requirements before opting in. Vercel's
+[AI SDK telemetry documentation](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)
+describes the equivalent full-content capture behavior.
+
+After a chat request, inspect the traces with:
+
+```bash
+npx agentpond sync
+npx agentpond traces list
+```
+
 ## 🚀 Going to prod
 
 If you've been developing the app locally, follow these instructions to deploy your app to a production Supabase project.

--- a/supabase/functions/_lib/agentpond.ts
+++ b/supabase/functions/_lib/agentpond.ts
@@ -1,0 +1,79 @@
+import { SpanStatusCode, trace, type Span } from 'npm:@opentelemetry/api@1.9.0';
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+} from 'npm:@opentelemetry/sdk-trace-base@2.9.0';
+import { createSupabaseSpanExporter } from 'npm:@agentpond/supabase@0.6.0';
+
+declare const EdgeRuntime: {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+const enabled = Deno.env.get('AGENTPOND_ENABLED') === 'true';
+const capture = {
+  recordInputs: true,
+  recordOutputs: true,
+} as const;
+
+let processor: BatchSpanProcessor | undefined;
+
+if (enabled) {
+  const exporter = createSupabaseSpanExporter();
+  processor = new BatchSpanProcessor(exporter);
+  const provider = new BasicTracerProvider({
+    spanProcessors: [processor],
+  });
+  trace.setGlobalTracerProvider(provider);
+}
+
+export function startOpenAISpan(
+  messages: unknown,
+  model: string
+): Span | undefined {
+  if (!enabled) return;
+
+  return trace.getTracer('chatgpt-your-files').startSpan('chat.completion', {
+    attributes: {
+      'openinference.span.kind': 'LLM',
+      'llm.model_name': model,
+      ...(capture.recordInputs
+        ? {
+            'input.value': JSON.stringify(messages),
+            'input.mime_type': 'application/json',
+          }
+        : {}),
+    },
+  });
+}
+
+export function finishOpenAISpan(
+  span: Span | undefined,
+  output?: string,
+  error?: unknown
+) {
+  if (!span) return;
+
+  if (output !== undefined && capture.recordOutputs) {
+    span.setAttributes({
+      'output.value': output,
+      'output.mime_type': 'text/plain',
+    });
+  }
+  if (error !== undefined) {
+    const exception = error instanceof Error ? error : new Error(String(error));
+    span.recordException(exception);
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: exception.message,
+    });
+  }
+  span.end();
+
+  if (processor) {
+    EdgeRuntime.waitUntil(
+      processor.forceFlush().catch((flushError) => {
+        console.error('Failed to flush AgentPond traces', flushError);
+      })
+    );
+  }
+}

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -3,6 +3,7 @@ import { OpenAIStream, StreamingTextResponse } from 'ai';
 import { codeBlock } from 'common-tags';
 import OpenAI from 'openai';
 import { Database } from '../_lib/database.ts';
+import { finishOpenAISpan, startOpenAISpan } from '../_lib/agentpond.ts';
 
 const openai = new OpenAI({
   apiKey: Deno.env.get('OPENAI_API_KEY'),
@@ -115,14 +116,26 @@ Deno.serve(async (req) => {
       ...messages,
     ];
 
-  const completionStream = await openai.chat.completions.create({
-    model: 'gpt-3.5-turbo-0125',
-    messages: completionMessages,
-    max_tokens: 1024,
-    temperature: 0,
-    stream: true,
-  });
+  const model = 'gpt-3.5-turbo-0125';
+  const span = startOpenAISpan(completionMessages, model);
 
-  const stream = OpenAIStream(completionStream);
-  return new StreamingTextResponse(stream, { headers: corsHeaders });
+  try {
+    const completionStream = await openai.chat.completions.create({
+      model,
+      messages: completionMessages,
+      max_tokens: 1024,
+      temperature: 0,
+      stream: true,
+    });
+
+    const stream = OpenAIStream(completionStream, {
+      onFinal(completion) {
+        finishOpenAISpan(span, completion);
+      },
+    });
+    return new StreamingTextResponse(stream, { headers: corsHeaders });
+  } catch (error) {
+    finishOpenAISpan(span, undefined, error);
+    throw error;
+  }
 });

--- a/supabase/migrations/20260727000000_agentpond_traces_bucket.sql
+++ b/supabase/migrations/20260727000000_agentpond_traces_bucket.sql
@@ -1,0 +1,6 @@
+-- AgentPond writes trace batches from Edge Functions with server-only access.
+-- Keep the bucket private because traces can contain document and chat content.
+insert into storage.buckets (id, name, public)
+values ('agentpond', 'agentpond', false)
+on conflict (id) do update
+set public = false;


### PR DESCRIPTION
## Summary

- initialize AgentPond's released Supabase integration for the chat Edge Function
- add explicit OpenInference spans around the streamed OpenAI completion
- flush the exporter through `EdgeRuntime.waitUntil()` after the stream finishes
- create a private `agentpond` Storage bucket and keep tracing opt-in through `AGENTPOND_ENABLED`

The span deliberately records the complete augmented message list and final model response with `recordInputs: true` and `recordOutputs: true`. The README documents that this can include uploaded document content and links to the [Vercel AI SDK telemetry documentation](https://ai-sdk.dev/docs/ai-sdk-core/telemetry) for the equivalent content-capture semantics.

## Validation

- `deno check --node-modules-dir=auto supabase/functions/_lib/agentpond.ts`
- the complete handler check reaches the repository's existing generated database-row typing mismatch at `documents.map(({ content }) => ...)`; the new tracing helper and streaming callback type-check
